### PR TITLE
fix(sidebar): Corrige seleção dinâmica do link ativo e adiciona hover. Closes #18

### DIFF
--- a/aluracast-frontend/src/components/Layout.tsx
+++ b/aluracast-frontend/src/components/Layout.tsx
@@ -66,13 +66,14 @@ const Layout: React.FC<LayoutProps> = ({ children, latestEpisode }) => {
         
         <nav>
           <ul>
-            <li className="menu-lateral__link menu-lateral__link--home ativo">
+            <li className={`menu-lateral__link menu-lateral__link--home ${router.pathname === '/' ? 'ativo' : ''}`}>
                 <Link href="/">Home</Link>
             </li>
-            <li className="menu-lateral__link menu-lateral__link--busca">
+                        <li className="menu-lateral__link menu-lateral__link--busca">
                 <Link href="#">Busca</Link>
             </li>
-            <li className="menu-lateral__link menu-lateral__link--biblioteca">
+
+            <li className={`menu-lateral__link menu-lateral__link--biblioteca ${router.pathname === '/biblioteca' ? 'ativo' : ''}`}>
                 {isLoggedIn ? (
                     <Link href="/biblioteca">Sua Biblioteca</Link>
                 ) : (

--- a/aluracast-frontend/src/styles/base.css
+++ b/aluracast-frontend/src/styles/base.css
@@ -1,4 +1,3 @@
-/*Reset*/
 a {
     text-decoration: none;
     color: inherit;
@@ -13,7 +12,6 @@ button {
 
 }
 
-/*Variaveis globais*/
 :root {
     --azul-escuro: #041833;
     --azul-medio: #154580;
@@ -28,7 +26,6 @@ button {
     box-sizing: border-box;
 }
 
-/* CORREÇÃO CRÍTICA PARA O LAYOUT NO CANTO */
 html {
     height: 100%;
 }
@@ -37,8 +34,6 @@ body {
     color: var(--cor-textos);
     background: var(--azul-degrade);
     font-family: var(--fonte-textos);
-    
-    /* CORREÇÃO CRÍTICA PARA O LAYOUT NO CANTO */
     height: 100%;
 }
 
@@ -48,13 +43,10 @@ body {
     
 }
 
-
-/*Aside*/
 .menu-lateral {
     background-color: var(--azul-escuro);
     padding: 2.5rem 1.25rem 2.5rem 2.5rem;
-    width: 230px; /* ✅ ESSA REGRA É CRÍTICA */
-    /* ... outras propriedades de cor/padding */
+    width: 230px;
 }
 
 .menu-lateral__link::before {
@@ -85,7 +77,6 @@ body {
 }
 
 .menu-lateral__link--biblioteca::before {
-    /* CORRIGIDO: de "../img/icone-biblioteca.svg" para "/assets/img/icone-biblioteca.svg" */
     font-size: 10%;
     content: url("/assets/img/icone-biblioteca.svg");
 }
@@ -96,16 +87,13 @@ body {
 }
 
 .menu-lateral__link--playlist::before {
-    /* CORRIGIDO: de "../img/icone-add_box.svg" para "/assets/img/icone-add_box.svg" */
     content: url("/assets/img/icone-add_box.svg");
 }
 
 .menu-lateral__link--podcasts::before {
-    /* CORRIGIDO: de "../img/icone-stars.svg" para "/assets/img/icone-stars.svg" */
     content: url("/assets/img/icone-stars.svg");
 }
 
-/*Header*/
 .cabecalho {
     padding-top: 2.5rem;
 }
@@ -116,9 +104,6 @@ body {
     margin-bottom: 2rem;
 }
 
-/*Main*/
-
-/*Estilos compartilhados pelos elementos presentes na seção horizontal e elementos da seção vertical*/
 .secao__titulo {
     font-weight: 700;
     font-size: 1.5rem;
@@ -252,4 +237,12 @@ body {
 
 .rodape__barra--volume {
     width: 4vw;
+}
+
+.menu-lateral__link:not(.ativo):hover {
+    background-color: var(--azul-medio);
+    border-radius: 5px;
+    padding: .75rem 0;
+    cursor: pointer;
+    opacity: 0.9;
 }


### PR DESCRIPTION
Esta Pull Request implementa a Issue #18, corrigindo o comportamento visual da Sidebar (menu lateral) para que a seleção de página seja dinâmica e o efeito de hover seja aplicado.

**Alterações Principais:**

1.  **CSS (`base.css`):**
    * Adicionada a pseudo-classe `:hover` à regra `.menu-lateral__link:not(.ativo)`.
    * Isso garante que os links fiquem com o fundo azul (`--azul-medio`) ao passar o mouse, conforme o Requisito 6.

2.  **Lógica (`Layout.tsx`):**
    * O principal bug foi corrigido: a classe `.ativo` não está mais "chumbada" (hard-coded) no link "Home".
    * A classe `.ativo` agora é aplicada dinamicamente ao `<li>` correto, usando o hook `useRouter()` para verificar o `router.pathname` (ex: `/` ou `/biblioteca`).

**Resultado:**
O menu lateral agora reflete com precisão a página em que o usuário está e fornece feedback visual correto (hover) ao usuário.

**Ação Pós-Merge:** O `Closes #18` no título garantirá que a Issue seja movida automaticamente para a coluna "Done" no nosso quadro Kanban.